### PR TITLE
U4X-1011: Change the sync task log to render per test to include the one of results sync log is available in the referredorders api

### DIFF
--- a/api/src/main/java/org/openmrs/module/ugandaemrsync/server/SyncConstant.java
+++ b/api/src/main/java/org/openmrs/module/ugandaemrsync/server/SyncConstant.java
@@ -92,6 +92,7 @@ public class SyncConstant {
     public static final String VIRAL_LOAD_SYNC_TASK_TYPE_UUID = "3551ca84-06c0-432b-9064-fcfeefd6f4ec";
 
     public static final String VIRAL_LOAD_SYNC_TYPE_UUID = "3551ca84-06c0-432b-9064-fcfeefd6f4ec";
+    public static final String VIRAL_LOAD_RESULT_SYNC_TYPE_UUID = "3396dcf0-2106-4e73-9b90-c63978c3a8b4";
     public static final String VL_PROGRAM_DATA_SYNC_TYPE_UUID = "f9b2fa5d-5d37-4fd9-b20a-a0cab664f520";
     public static final String FHIRSERVER_SYNC_TASK_TYPE_UUID = "3c1ce940-8ade-11ea-bc55-0242ac130003";
     public static final String VIRAL_LOAD_RESULT_PULL_TYPE_UUID = "3396dcf0-2106-4e73-9b90-c63978c3a8b4";

--- a/omod/src/main/java/org/openmrs/module/ugandaemrsync/web/resource/ReferralOrderResource.java
+++ b/omod/src/main/java/org/openmrs/module/ugandaemrsync/web/resource/ReferralOrderResource.java
@@ -242,12 +242,27 @@ public class ReferralOrderResource extends DelegatingCrudResource<ReferralOrder>
         if (order == null || order.getAccessionNumber() == null) {
             return null;
         }
+
         UgandaEMRSyncService syncService = Context.getService(UgandaEMRSyncService.class);
-        SyncTaskType syncTaskType = syncService.getSyncTaskTypeByUUID(VIRAL_LOAD_SYNC_TYPE_UUID);
-        List<SyncTask> syncTaskLog = syncService.getSyncTasksBySyncTaskId(order.getAccessionNumber()).stream().filter(syncTask -> syncTask.getSyncTaskType().equals(syncTaskType)).collect(Collectors.toList());
-        if (!syncTaskLog.isEmpty()) {
-            return syncTaskLog.get(0);
+        SyncTaskType requestType = syncService.getSyncTaskTypeByUUID(VIRAL_LOAD_SYNC_TYPE_UUID);
+        SyncTaskType resultType = syncService.getSyncTaskTypeByUUID(VIRAL_LOAD_RESULT_SYNC_TYPE_UUID);
+
+        List<SyncTask> syncTasks = syncService.getSyncTasksBySyncTaskId(order.getAccessionNumber());
+
+        // Prioritize result sync task
+        for (SyncTask task : syncTasks) {
+            if (task.getSyncTaskType().equals(resultType)) {
+                return task;
+            }
         }
+
+        // Fallback to request sync task
+        for (SyncTask task : syncTasks) {
+            if (task.getSyncTaskType().equals(requestType)) {
+                return task;
+            }
+        }
+
         return null;
     }
 


### PR DESCRIPTION
https://metsprogramme.atlassian.net/browse/U4X-1011